### PR TITLE
Strip on build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/AustinWise/smeagol/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+strip = "symbols"
+
 [build-dependencies]
 ring = "0.16.20"
 


### PR DESCRIPTION
Now that 1.59 has been release, we can strip symbols from release binaries in a cross platform way.