### PR TITLE
implement transclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,13 +1398,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1691,6 +1691,7 @@ dependencies = [
  "pretty_env_logger",
  "pulldown-cmark",
  "rand",
+ "regex",
  "ring",
  "rocket",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.18.0"
 pretty_env_logger = "0.5"
 pulldown-cmark = { version = "0.9", default-features = false }
 rand = "0.8.5"
+regex = { version = "1.10.3", features = ["std"] }
 rocket = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 strum = "0.25"

--- a/src/wiki.rs
+++ b/src/wiki.rs
@@ -216,7 +216,7 @@ impl Wiki {
 
     pub fn read_file(&self, file_path: &[&str]) -> Result<Vec<u8>, MyError> {
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"\[\[(.+?)\]\]").unwrap();
+            static ref RE: Regex = Regex::new(r"^{{(.+?)}}$").unwrap();
         }
         let mut res = self.0.repository.read_file(file_path);
         if let Ok(mut bytes) = res {

--- a/src/wiki.rs
+++ b/src/wiki.rs
@@ -216,7 +216,7 @@ impl Wiki {
 
     pub fn read_file(&self, file_path: &[&str]) -> Result<Vec<u8>, MyError> {
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"\[\[(.*?)\]\]").unwrap();
+            static ref RE: Regex = Regex::new(r"\[\[(.+?)\]\]").unwrap();
         }
         let mut res = self.0.repository.read_file(file_path);
         if let Ok(mut bytes) = res {


### PR DESCRIPTION
This implements a WikiMedia feature they call "transclusion", which pulls one wiki page into another.

Right now, it uses `[[filename.md]]` to pull in another file.

Flaws:
- No security: no defense against infinite loops.  This could be added by limiting the depth of transclusion possible
- No security: no defense against directory traversal when running with `--fs`.
- No file-type checking: if a JPG contains `[[...]]` it will try to transclude and break the image

If any of these are too much for you to accept, please let me know and I can see if I can make the implementation more robust.