### PR TITLE
Update some GitHub actions

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,3 +4,8 @@
 #rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 #[target.aarch64-unknown-linux-gnu]
 #rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+# We only link to DLLs in System32, so limit the OS loader to looking in there.
+# https://learn.microsoft.com/cpp/build/reference/dependentloadflag
+[target.'cfg(target_env = "msvc")']
+rustflags = ["-C", "link-arg=/DEPENDENTLOADFLAG:0x800"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-
     # See: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
     # And also https://github.com/rust-lang/rustup/blob/25dc87dc605adc0843c9369063333997ae806008/.github/workflows/linux-builds-on-stable.yaml#L81
     - name: Cache cargo registry and git trees
@@ -62,18 +56,13 @@ jobs:
         key: ${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
+      run: cargo build
 
     - name: cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+      run: cargo build
 
     - name: Clear the cargo caches
       if: ${{ ! steps.do-cache-cargo.outputs.cache-hit }}
       run: |
         cargo install cargo-cache --no-default-features --features ci-autoclean
         cargo-cache
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -43,7 +43,7 @@ jobs:
     # And also https://github.com/rust-lang/rustup/blob/25dc87dc605adc0843c9369063333997ae806008/.github/workflows/linux-builds-on-stable.yaml#L81
     - name: Cache cargo registry and git trees
       id: do-cache-cargo
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -56,7 +56,7 @@ jobs:
       shell: bash
     - name: Cache cargo build
       id: do-cache-target
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: target
         key: ${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       RELEASE_BODY_FILE_NAME: __release_body_file_dont_commit__.md
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create release body file
         shell: bash
         run: |
@@ -113,7 +113,7 @@ jobs:
           echo "RUSTFLAGS=-C target-feature=+crt-static" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Shellcheck
       shell: bash
       run: |


### PR DESCRIPTION
There are warnings about Node 16 deprecation.

TODO: figure out what to do about the dead Rust GitHub actions.