### PR TITLE
Display version number and Git revision in pages and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,7 @@ dependencies = [
  "askama",
  "bitflags",
  "clap",
+ "const_format",
  "git2",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +339,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +368,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -812,6 +847,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1048,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_debug"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1280,6 +1345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -1793,6 +1867,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d5625ed609cf66d7e505e7d487aca815626dc4ebb6c0dd07637ca61a44651a6"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1945,7 @@ dependencies = [
  "ring",
  "rocket",
  "serde",
+ "shadow-rs",
  "strum",
  "strum_macros",
  "tantivy",
@@ -2175,7 +2263,9 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -2366,6 +2456,32 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tz-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1450bf2b99397e72070e7935c89facaa80092ac812502200375f1f7d33c71a1"
+
+[[package]]
+name = "tzdb"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2ea5956f295449f47c0b825c5e109022ff1a6a53bb4f77682a87c2341fbf5"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4c81d75033770e40fbd3643ce7472a1a9fd301f90b7139038228daf8af03ec"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "ubyte"
@@ -2596,6 +2712,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ strip = "symbols"
 
 [build-dependencies]
 ring = "0.17"
+shadow-rs = "1.1.1"
 
 [dependencies]
 askama = "0.12"
@@ -35,6 +36,7 @@ strum_macros = "0.26"
 tantivy = "0.22"
 thiserror = "2.0"
 toml = "0.8"
+shadow-rs = { version = "1.1.1", default-features = false }
 
 # just to satisfy a dependabot warning: CVE-2024-12224
 url = "2.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tantivy = "0.22"
 thiserror = "2.0"
 toml = "0.8"
 shadow-rs = { version = "1.1.1", default-features = false }
+const_format = "0.2.34"
 
 # just to satisfy a dependabot warning: CVE-2024-12224
 url = "2.5.4"

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use ring::digest::{Context, Digest, SHA256};
+use shadow_rs::{BuildPattern, ShadowBuilder};
 
 struct ContextWriter(Context);
 
@@ -148,6 +149,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rustc-link-arg-bins=/MANIFEST:embed");
         println!("cargo:rustc-link-arg-bins=/MANIFESTINPUT:windows_manifest.xml");
     }
+
+    ShadowBuilder::builder()
+        .build_pattern(BuildPattern::RealTime)
+        .build()
+        .unwrap();
 
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,8 +7,12 @@ use serde::Deserialize;
 use crate::error::MyError;
 use crate::repository::{RepoBox, RepositoryItem};
 
+use shadow_rs::shadow;
+
+shadow!(build);
+
 #[derive(clap::Parser, Debug, Clone)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = const_format::formatcp!("{}({})", build::PKG_VERSION, build::SHORT_COMMIT), about, long_about = None)]
 pub struct Args {
     /// Path to the directory containing the wiki Git repository.
     git_repo: Option<PathBuf>,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -4,7 +4,12 @@ use crate::assets::favicon_png_uri;
 use crate::assets::primer_css_uri;
 use crate::wiki::SearchResult;
 
+use shadow_rs::shadow;
+
+shadow!(build);
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const SHORT_COMMIT: &str = build::SHORT_COMMIT;
 
 pub struct Breadcrumb<'a> {
     name: &'a str,
@@ -28,6 +33,7 @@ struct ViewPageTemplate<'a> {
     content: &'a str,
     breadcrumbs: Vec<Breadcrumb<'a>>,
     version: &'a str,
+    short_sha: &'a str,
 }
 
 pub fn render_page(
@@ -48,6 +54,7 @@ pub fn render_page(
         content,
         breadcrumbs,
         version: VERSION,
+        short_sha: SHORT_COMMIT,
     };
     // TODO: render into a stream directly instead of crating this String.
     page.render()
@@ -64,6 +71,7 @@ struct PagePlaceholderTemplate<'a> {
     overview_url: &'a str,
     breadcrumbs: Vec<Breadcrumb<'a>>,
     version: &'a str,
+    short_sha: &'a str,
 }
 
 pub fn render_page_placeholder(
@@ -84,6 +92,7 @@ pub fn render_page_placeholder(
         overview_url,
         breadcrumbs,
         version: VERSION,
+        short_sha: SHORT_COMMIT,
     };
     template.render()
 }
@@ -104,6 +113,7 @@ struct EditTemplate<'a> {
     breadcrumbs: Vec<Breadcrumb<'a>>,
     authenticity_token: &'a str,
     version: &'a str,
+    short_sha: &'a str,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -132,6 +142,7 @@ pub fn render_edit_page(
         breadcrumbs,
         authenticity_token,
         version: VERSION,
+        short_sha: SHORT_COMMIT,
     };
     template.render()
 }
@@ -160,6 +171,7 @@ struct OverviewTemplate<'a> {
     files: Vec<DirectoryEntry<'a>>,
     overview_url: &'a str,
     version: &'a str,
+    short_sha: &'a str,
 }
 
 pub fn render_overview(
@@ -183,6 +195,7 @@ pub fn render_overview(
         files,
         overview_url: "/overview",
         version: VERSION,
+        short_sha: SHORT_COMMIT,
     };
     template.render()
 }
@@ -200,6 +213,7 @@ struct SearchResultsTemplate<'a> {
     next_url: Option<String>,
     overview_url: &'a str,
     version: &'a str,
+    short_sha: &'a str,
 }
 
 pub fn render_search_results(
@@ -222,6 +236,7 @@ pub fn render_search_results(
         next_url,
         overview_url: "/overview",
         version: VERSION,
+        short_sha: SHORT_COMMIT,
     };
     template.render()
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -4,6 +4,8 @@ use crate::assets::favicon_png_uri;
 use crate::assets::primer_css_uri;
 use crate::wiki::SearchResult;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub struct Breadcrumb<'a> {
     name: &'a str,
     href: String,
@@ -25,6 +27,7 @@ struct ViewPageTemplate<'a> {
     overview_url: &'a str,
     content: &'a str,
     breadcrumbs: Vec<Breadcrumb<'a>>,
+    version: &'a str,
 }
 
 pub fn render_page(
@@ -44,6 +47,7 @@ pub fn render_page(
         overview_url,
         content,
         breadcrumbs,
+        version: VERSION,
     };
     // TODO: render into a stream directly instead of crating this String.
     page.render()
@@ -59,6 +63,7 @@ struct PagePlaceholderTemplate<'a> {
     create_url: &'a str,
     overview_url: &'a str,
     breadcrumbs: Vec<Breadcrumb<'a>>,
+    version: &'a str,
 }
 
 pub fn render_page_placeholder(
@@ -78,6 +83,7 @@ pub fn render_page_placeholder(
         create_url,
         overview_url,
         breadcrumbs,
+        version: VERSION,
     };
     template.render()
 }
@@ -97,6 +103,7 @@ struct EditTemplate<'a> {
     content: &'a str,
     breadcrumbs: Vec<Breadcrumb<'a>>,
     authenticity_token: &'a str,
+    version: &'a str,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -124,6 +131,7 @@ pub fn render_edit_page(
         content,
         breadcrumbs,
         authenticity_token,
+        version: VERSION,
     };
     template.render()
 }
@@ -151,6 +159,7 @@ struct OverviewTemplate<'a> {
     directories: Vec<DirectoryEntry<'a>>,
     files: Vec<DirectoryEntry<'a>>,
     overview_url: &'a str,
+    version: &'a str,
 }
 
 pub fn render_overview(
@@ -173,6 +182,7 @@ pub fn render_overview(
         directories,
         files,
         overview_url: "/overview",
+        version: VERSION,
     };
     template.render()
 }
@@ -189,6 +199,7 @@ struct SearchResultsTemplate<'a> {
     prev_url: Option<String>,
     next_url: Option<String>,
     overview_url: &'a str,
+    version: &'a str,
 }
 
 pub fn render_search_results(
@@ -210,6 +221,7 @@ pub fn render_search_results(
         prev_url,
         next_url,
         overview_url: "/overview",
+        version: VERSION,
     };
     template.render()
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -14,6 +14,10 @@
             padding: 0 1em 0 1em;
         }
 
+        footer {
+          text-align: center;
+        }
+
         .markdown-body {
             padding: 1em 1em 1em 0;
         }
@@ -102,6 +106,9 @@
             {% block content %}{% endblock %}
         </div>
     </main>
+    <footer>
+      <a href="https://smeagol.dev">smeagol</a> - {{version}}
+    </footer>
 
 </body>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -107,7 +107,7 @@
         </div>
     </main>
     <footer>
-      <a href="https://smeagol.dev">smeagol</a> - {{version}}
+      <a href="https://smeagol.dev">smeagol</a> - {{version}}({{short_sha}})
     </footer>
 
 </body>


### PR DESCRIPTION
```console
> cargo run -- --version
   Compiling smeagol-wiki v0.4.11 (/home/kachick/repos/github.com/AustinWise/smeagol)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.12s
     Running `target/debug/smeagol-wiki --version`
smeagol-wiki 0.4.11(8be15277)
```

![image](https://github.com/user-attachments/assets/dc0f9b8b-2751-41ea-a816-0aaeb54369ac)

Resolves #38

To keep the changes organized, I’ve split them into separate commits.
Adding the Git SHA-1 required some dependency updates as well.
