### PR TITLE
Update deprecated ubuntu-20.04 runner with ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         include:
         - build: linux-x64
           os: ubuntu
-          image: ubuntu-20.04
+          image: ubuntu-24.04
           target: x86_64-unknown-linux-gnu
         - build: macos-x64
           os: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+-*" # prerelease
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       id: ${{ steps.release.outputs.id }}
       upload_url: ${{ steps.release.outputs.upload_url }}
@@ -61,17 +61,17 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu
-            image: ubuntu-20.04
+            image: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             use-cross: false
           - build: linux-arm32
             os: ubuntu
-            image: ubuntu-20.04
+            image: ubuntu-24.04
             target: arm-unknown-linux-gnueabihf
             use-cross: true
           - build: linux-arm64
             os: ubuntu
-            image: ubuntu-20.04
+            image: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - build: macos-x64
@@ -167,7 +167,7 @@ jobs:
   publish-release:
     if: github.ref_type == 'tag'
     needs: ["create-release", "build-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Publish release, by setting draft to false
         shell: bash

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,7 +11,7 @@ on:
       - '**.sh'
 jobs:
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
ref: https://github.com/AustinWise/smeagol/pull/73#issuecomment-2805140855

This PR updates deprecated GitHub Actions to fix the current CI failures.

The changes seem to be working at least for `ci.yml`.


