### PR TITLE
Add Nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Smeagol - locally hosted wiki
 
+[![Packaging status](https://repology.org/badge/latest-versions/smeagol.svg?header=PACKAGE)](https://repology.org/project/smeagol/versions)
+
 The goal of this project is to create a wiki software with these properties:
 
 * Compatible with GitHub. This means:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ If you use the Rust programming language, you can also install this tool using C
 cargo install smeagol-wiki
 ```
 
+Nix users can also install it through nixpkgs:
+
+```bash
+nix-env --install --attr nixpkgs.smeagol
+```
+
 Download the [latest release from GitHub](https://github.com/AustinWise/smeagol/releases/latest).
 Extract the `smeagol-wiki` executable from the compressed archive.
 `smeagol-wiki` is a command line application. It needs a directory

--- a/site/index.html
+++ b/site/index.html
@@ -209,7 +209,7 @@
     <h2>Learn More</h2>
     <div>
         See the <a href="https://github.com/AustinWise/smeagol#getting-started">README</a> for more information
-        information on how to use Smeagol.
+        on how to use Smeagol.
     </div>
 
     <div class="github-ribbon">


### PR DESCRIPTION
This PR adds installation instructions for Nix, demonstrating the approach discussed in https://github.com/AustinWise/smeagol/issues/13#issuecomment-3243591381.

I personally use flakes for this purpose, as I only enable Smeagol in a wiki repository. 
However, since flakes are still an experimental feature and to align with the other installation methods in the current README, I have added the nix-env method.
I have verified that this `nix-env` script works correctly in an [official Docker image](https://hub.docker.com/r/nixos/nix).


```bash
podman run -it nixos/nix:2.31.0
```

```console
bash-5.2# nix-env --install --attr nixpkgs.smeagol
installing 'smeagol-0.5.0'
this path will be fetched (3.99 MiB download, 16.34 MiB unpacked):
  /nix/store/icmnmyp2zdnr6slbbb49kk1bv4djqx4y-smeagol-0.5.0
copying path '/nix/store/icmnmyp2zdnr6slbbb49kk1bv4djqx4y-smeagol-0.5.0' from 'https://cache.nixos.org'...
building '/nix/store/spa80n9654011ikxvb5q70s9x9bmqbd0-user-environment.drv'...
bash-5.2# smeagol-wiki --help
A personal wiki webserver. Work in progress.

Usage: smeagol-wiki [OPTIONS] [GIT_REPO]

Arguments:
  [GIT_REPO]  Path to the directory containing the wiki Git repository

Options:
      --host <HOST>  The IP address to bind to. Defaults to 127.0.0.1
      --port <PORT>  The TCP Port to bind to. Defaults to 8000
      --fs           Use the file system to read the wiki, not Git
  -h, --help         Print help
  -V, --version      Print version
```

You can custom repology badge pattern with: https://repology.org/project/smeagol/badges
